### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "usehooks-ts": "^3.1.0",
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.6.0",

--- a/src/app/components/AiChatSidebar.tsx
+++ b/src/app/components/AiChatSidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import VoiceButton from '../components/VoiceButton';
 import type {
   SpeechRecognition,
@@ -283,7 +284,7 @@ export default function AiChatSidebar({ isOpen, onClose }: { isOpen: boolean; on
                   <div
                     className="text-sm leading-relaxed message-content"
                     dangerouslySetInnerHTML={{
-                      __html: formatMessageContent(msg.content)
+                      __html: DOMPurify.sanitize(formatMessageContent(msg.content))
                     }}
                   />
 


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/4](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/4)

To fix the issue, the user input must be sanitized before being injected into the DOM. This can be achieved by:
1. Using a library like `DOMPurify` to sanitize the HTML content generated by `formatMessageContent`. `DOMPurify` is a well-known library for preventing XSS by cleaning HTML.
2. Replacing the `dangerouslySetInnerHTML` usage with sanitized content to ensure that only safe HTML is rendered.

Changes required:
- Install the `dompurify` library.
- Import `DOMPurify` in the file.
- Sanitize the output of `formatMessageContent` before passing it to `dangerouslySetInnerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
