### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "usehooks-ts": "^3.1.0",
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.6.0",

--- a/src/app/(protected)/meetings/[meetingId]/_components/IssueList.tsx
+++ b/src/app/(protected)/meetings/[meetingId]/_components/IssueList.tsx
@@ -16,6 +16,7 @@ import {
 import { api, RouterOutputs } from "@/trpc/react";
 import { VideoIcon } from "lucide-react";
 import React from "react";
+import DOMPurify from "dompurify";
 import { cn } from "@/lib/utils";
 
 function IssueCard({
@@ -158,20 +159,22 @@ User Question: ${userMessage}`,
                       )}>
                         {msg.role === "assistant" ? (
                           <div dangerouslySetInnerHTML={{ 
-                            __html: msg.content
-                              .replace(/^•\s+/gm, '• ') // Format bullet points
-                              .replace(/\n\n/g, '</p><p>') // Convert double newlines to paragraphs
-                              .replace(/^([^•].+?)$/gm, '$1') // Regular lines
-                              .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') // Bold text
-                              .replace(/\*([^\*]+)\*/g, '<em>$1</em>') // Italic text
-                              .split('\n')
-                              .map(line => {
-                                if (line.startsWith('•')) {
-                                  return `<div class="flex gap-2 items-start"><span class="text-primary">•</span><span>${line.substring(2)}</span></div>`;
-                                }
-                                return line;
-                              })
-                              .join('')
+                            __html: DOMPurify.sanitize(
+                              msg.content
+                                .replace(/^•\s+/gm, '• ') // Format bullet points
+                                .replace(/\n\n/g, '</p><p>') // Convert double newlines to paragraphs
+                                .replace(/^([^•].+?)$/gm, '$1') // Regular lines
+                                .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') // Bold text
+                                .replace(/\*([^\*]+)\*/g, '<em>$1</em>') // Italic text
+                                .split('\n')
+                                .map(line => {
+                                  if (line.startsWith('•')) {
+                                    return `<div class="flex gap-2 items-start"><span class="text-primary">•</span><span>${line.substring(2)}</span></div>`;
+                                  }
+                                  return line;
+                                })
+                                .join('')
+                            )
                           }} />
                         ) : (
                           <p className="text-foreground/80">{msg.content}</p>


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/2](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/2)

To fix the issue, we need to sanitize `msg.content` before passing it to `dangerouslySetInnerHTML`. A well-known library like `DOMPurify` can be used to clean the input and remove any potentially malicious content. This ensures that only safe HTML is rendered in the DOM.

Steps to fix:
1. Install the `dompurify` library to sanitize HTML content.
2. Import `DOMPurify` into the file.
3. Use `DOMPurify.sanitize` to clean `msg.content` before rendering it with `dangerouslySetInnerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
