### PR TITLE
Potential fix for code scanning alert no. 194: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/(protected)/advanced/MetaDataGenerator.tsx
+++ b/src/app/(protected)/advanced/MetaDataGenerator.tsx
@@ -291,13 +291,23 @@ const MetaDataGeneratorModal = ({ open, onClose }: { open: boolean; onClose: () 
     const title = form.getValues('title');
     const description = form.getValues('description');
     const image = form.getValues('ogImage') || '';
+    const isValidUrl = (url: string) => {
+      try {
+        const parsedUrl = new URL(url);
+        return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+      } catch {
+        return false;
+      }
+    };
+
+    const sanitizedImage = isValidUrl(image) ? image : '';
 
     return (
       <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 mb-4">
         <div className="flex flex-col gap-2">
-          {image && (
+          {sanitizedImage && (
             <img
-              src={image}
+              src={sanitizedImage}
               alt="Preview image"
               className="w-full h-48 object-cover rounded-lg mb-2"
               onError={(e) => ((e.target as HTMLImageElement).style.display = 'none')}


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/194](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/194)

To fix the issue, we should validate and sanitize the `image` value before using it. Specifically:
1. Use a utility function to validate that `image` is a safe and valid URL.
2. Allow only properly formatted URLs (e.g., starting with `http://` or `https://`) to be used as the `src` attribute.
3. If the `image` value is invalid or empty, provide a fallback or prevent the `<img>` element from rendering.

We'll create a utility function `isValidUrl` to validate the `image` URL. If the `image` value is invalid, the `<img>` element won't be rendered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
