### PR TITLE
Potential fix for code scanning alert no. 196: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/(protected)/meetings/[meetingId]/_components/IssueList.tsx
+++ b/src/app/(protected)/meetings/[meetingId]/_components/IssueList.tsx
@@ -441,22 +441,21 @@ const IssueList = ({ meetingId }: Props) => {
                         {msg.role === 'assistant' ? (
                           <div
                             dangerouslySetInnerHTML={{
-                              __html: msg.content
-                                .replace(/^•\s+/gm, '• ') // Format bullet points
-                                .replace(/\n\n/g, '</p><p>') // Convert double newlines to paragraphs
-                                .replace(/^([^•].+?)$/gm, '$1') // Regular lines
-                                .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') // Bold text
-                                .replace(/\*([^\*]+)\*/g, '<em>$1</em>') // Italic text
-                                .split('\n')
-                                .map((line) => {
-                                  if (line.startsWith('•')) {
-                                    return `<div class="flex gap-2 items-start"><span class="text-primary">•</span><span>${line.substring(2)}</span></div>`;
-                                  }
-                                  return line;
-                                })
-                                .join(''),
-                            }}
-                          />
+                              __html: DOMPurify.sanitize(
+                                msg.content
+                                  .replace(/^•\s+/gm, '• ') // Format bullet points
+                                  .replace(/\n\n/g, '</p><p>') // Convert double newlines to paragraphs
+                                  .replace(/^([^•].+?)$/gm, '$1') // Regular lines
+                                  .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') // Bold text
+                                  .replace(/\*([^\*]+)\*/g, '<em>$1</em>') // Italic text
+                                  .split('\n')
+                                  .map((line) => {
+                                    if (line.startsWith('•')) {
+                                      return `<div class="flex gap-2 items-start"><span class="text-primary">•</span><span>${line.substring(2)}</span></div>`;
+                                    }
+                                    return line;
+                                  })
+                                  .join(''),
                         ) : (
                           <p className="text-foreground/80">{msg.content}</p>
                         )}


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/196](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/196)

To resolve the vulnerability, the untrusted data (`msg.content`) should be sanitized before being rendered using `dangerouslySetInnerHTML`. The `DOMPurify` library, which is already imported, can be utilized to sanitize HTML content effectively. This ensures that potentially malicious input is cleaned and safe to interpret as HTML.

The fix involves:
1. Adding a sanitization step using `DOMPurify.sanitize` to process `msg.content` before assigning it to `dangerouslySetInnerHTML`.
2. Retaining existing formatting logic (`replace`, `map`, etc.) while ensuring sanitized data is used as the final input for `dangerouslySetInnerHTML`.

Changes will be made in the block of code around line 444.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
