### PR TITLE
Potential fix for code scanning alert no. 216: Incomplete URL substring sanitization

### DIFF
--- a/src/components/updates/screen.tsx
+++ b/src/components/updates/screen.tsx
@@ -164,7 +164,14 @@ export default function MaintenanceScreen() {
             <span className="font-semibold text-sky-700 dark:text-sky-300 text-lg">Watch What’s New:</span>
             <div className="flex flex-col gap-4 mt-2">
               {info.videos.map((vid, i) => (
-                vid.includes('youtube.com') ? (
+                (() => {
+                  try {
+                    const { host } = new URL(vid);
+                    return ['youtube.com', 'www.youtube.com'].includes(host);
+                  } catch {
+                    return false;
+                  }
+                })() ? (
                   <div key={i} className="aspect-video w-full rounded-xl overflow-hidden shadow border-2 border-sky-200 dark:border-sky-800">
                     <iframe
                       src={vid}


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/216](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/216)

To fix the issue, the code should parse the URL using a library like `URL` (available in modern JavaScript environments) and check the `host` property to ensure it matches an explicit whitelist of allowed hosts. Specifically, the check should verify that the `host` is `youtube.com` or `www.youtube.com`, as these are the valid hosts for YouTube videos.

The fix involves replacing the substring check `vid.includes('youtube.com')` with a more robust check that parses the URL and validates the host against a whitelist. The `URL` constructor is a straightforward and reliable way to achieve this.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
