### PR TITLE
Potential fix for code scanning alert no. 277: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -15,7 +15,18 @@ if (process.env.REDIS_URL || process.env.REDIS_URL_NEW) {
       redisUrl = redisUrl.replace(/%20/g, ' ').trim();
     }
 
-    if (redisUrl.includes('upstash.io')) {
+    let redisHost: string | null = null;
+    try {
+      const parsedUrl = new URL(redisUrl);
+      redisHost = parsedUrl.hostname;
+    } catch (e) {
+      // fallback: try to extract host with regex if URL parsing fails
+      const hostMatch = redisUrl.match(/\/\/([^@\/:]+@)?([^:\/?#]+)/);
+      if (hostMatch && hostMatch[2]) {
+        redisHost = hostMatch[2];
+      }
+    }
+    if (redisHost && (redisHost === 'upstash.io' || redisHost.endsWith('.upstash.io'))) {
       if (redisUrl.includes('--tls') || redisUrl.includes('-u')) {
         const redisUrlMatch = redisUrl.match(/(redis:\/\/.*?@.*?:[0-9]+)/);
         if (redisUrlMatch && redisUrlMatch[1]) {


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/277](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/277)

To fix the problem, the code should parse the `redisUrl` and check the host component explicitly, rather than using a substring match. This can be done using the standard `URL` class available in Node.js. The check should ensure that the host ends with `upstash.io` (to allow for subdomains like `mydb.upstash.io`), but not match hosts like `evil-upstash.io.evil.com`. The fix should be applied in the block where `redisUrl.includes('upstash.io')` is used (line 18), replacing it with a check on the parsed host. No new dependencies are needed, as the `URL` class is built-in.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
