### PR TITLE
Potential fix for code scanning alert no. 276: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -18,7 +18,18 @@ if (process.env.REDIS_URL || process.env.REDIS_URL_NEW) {
       redisUrl = redisUrl.replace(/%20/g, ' ').trim();
     }
 
-    if (redisUrl.includes('upstash.io')) {
+    let redisHost = '';
+    try {
+      const parsedUrl = new URL(redisUrl);
+      redisHost = parsedUrl.hostname;
+    } catch (e) {
+      // fallback: try to extract host from string if URL parsing fails
+      const match = redisUrl.match(/redis:\/\/(?:.*@)?([^:/?#]+)(?::\d+)?/);
+      if (match && match[1]) {
+        redisHost = match[1];
+      }
+    }
+    if (redisHost.endsWith('upstash.io')) {
       if (redisUrl.includes('--tls') || redisUrl.includes('-u')) {
         const redisUrlMatch = redisUrl.match(/(redis:\/\/.*?@.*?:[0-9]+)/);
         if (redisUrlMatch && redisUrlMatch[1]) {


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/276](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/276)

To fix the problem, the code should parse the Redis URL and check the host component explicitly, rather than using a substring match. This can be done using the standard `URL` class available in Node.js. Specifically, replace `redisUrl.includes('upstash.io')` with a check that parses the URL and verifies that the host ends with `'upstash.io'` (to allow for subdomains like `eu1-upstash.io`). This change should be made in the block starting at line 21 in `src/lib/gemini.ts`. No additional dependencies are required, as the `URL` class is built-in.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
