### PR TITLE
Potential fix for code scanning alert no. 278: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -29,7 +29,12 @@ if (process.env.REDIS_URL || process.env.REDIS_URL_NEW) {
         redisHost = match[1];
       }
     }
-    if (redisHost.endsWith('upstash.io')) {
+    // Only allow exact 'upstash.io' or direct subdomains (e.g., 'foo.upstash.io')
+    const hostParts = redisHost.split('.');
+    const isUpstash =
+      (hostParts.length === 2 && redisHost === 'upstash.io') ||
+      (hostParts.length > 2 && hostParts.slice(-2).join('.') === 'upstash.io');
+    if (isUpstash) {
       if (redisUrl.includes('--tls') || redisUrl.includes('-u')) {
         const redisUrlMatch = redisUrl.match(/(redis:\/\/.*?@.*?:[0-9]+)/);
         if (redisUrlMatch && redisUrlMatch[1]) {


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/278](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/278)

To fix the problem, we need to ensure that the host is either exactly `upstash.io` or a direct subdomain of `upstash.io` (e.g., `foo.upstash.io`). The best way to do this is to check if the host is equal to `upstash.io` or matches the pattern `*.upstash.io` (where `*` is a single subdomain label). This can be done by splitting the hostname on `.` and ensuring the last two labels are `upstash.io`, and that there is at least one label before them. The change should be made in the block where `redisHost.endsWith('upstash.io')` is checked (line 32). No new dependencies are needed, as this can be done with standard string/array methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
