### PR TITLE
Potential fix for code scanning alert no. 337: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
     "usehooks-ts": "^3.1.1",
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/src/app/api/verify-password/route.ts
+++ b/src/app/api/verify-password/route.ts
@@ -5,7 +5,7 @@ import { auth } from '@clerk/nextjs/server';
 import { rateLimit, resetRateLimit } from '@/lib/rate-limit';
 import { verifyRecaptchaV2 } from '@/lib/recaptcha';
 import { readReplicaDb } from '@/server/read-replica-db';
-
+import sanitizeHtml from 'sanitize-html';
 function checkForSuspiciousPatterns(req: NextRequest): boolean {
   try {
     const userAgent = req.headers.get('user-agent') || '';
@@ -108,14 +108,7 @@ export async function POST(req: NextRequest) {
     }
     const sanitizedPassword =
       typeof password === 'string'
-        ? (() => {
-            let prev, curr = password;
-            do {
-              prev = curr;
-              curr = curr.replace(/<script.*?>.*?<\/script>/gi, '');
-            } while (curr !== prev);
-            return curr.trim();
-          })()
+        ? sanitizeHtml(password, { allowedTags: [], allowedAttributes: {} }).trim()
         : password;
     if (
       !sanitizedPassword ||


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/337](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/337)

To fix the problem, we should avoid using a custom regular expression to sanitize HTML and instead use a well-tested library such as `sanitize-html` to remove any potentially dangerous HTML tags from the password input. This will ensure that all variants of `<script>` tags (including those with extra attributes or whitespace) are properly removed. The change should be made in the region where `sanitizedPassword` is computed (lines 109–119). We will need to import `sanitize-html` at the top of the file and replace the custom regex-based sanitization with a call to `sanitizeHtml(password, { allowedTags: [], allowedAttributes: {} })`, which strips all HTML tags and attributes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
