### PR TITLE
Potential fix for code scanning alert no. 338: Bad HTML filtering regexp

### DIFF
--- a/src/app/api/unlock/route.ts
+++ b/src/app/api/unlock/route.ts
@@ -5,6 +5,7 @@ import { auth } from '@clerk/nextjs/server';
 import { rateLimit, resetRateLimit } from '@/lib/rate-limit';
 import { verifyRecaptchaV2 } from '@/lib/recaptcha';
 import { readReplicaDb } from '@/server/read-replica-db';
+import sanitizeHtml from 'sanitize-html';
 
 export async function POST(req: NextRequest) {
   try {
@@ -31,23 +32,16 @@ export async function POST(req: NextRequest) {
     if (newPassword && newPassword.length > 30) {
       return NextResponse.json({ success: false, error: 'New password too long' }, { status: 400 });
     }
-    function removeAllScriptTags(input: string): string {
-      let previous: string;
-      do {
-        previous = input;
-        input = input.replace(/<script.*?>.*?<\/script>/gi, '');
-      } while (input !== previous);
-      return input.trim();
-    }
+    // Use sanitize-html to remove all HTML tags, including script tags
 
     const sanitizedNewPassword =
       typeof newPassword === 'string'
-        ? removeAllScriptTags(newPassword)
+        ? sanitizeHtml(newPassword, { allowedTags: [], allowedAttributes: {} }).trim()
         : newPassword;
 
     const sanitizedPassword =
       typeof currentPassword === 'string'
-        ? removeAllScriptTags(currentPassword)
+        ? sanitizeHtml(currentPassword, { allowedTags: [], allowedAttributes: {} }).trim()
         : currentPassword;
     if (
       !sanitizedPassword ||


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/338](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/338)

The best way to fix this problem is to avoid using a custom regular expression for HTML sanitization and instead use a well-tested library designed for this purpose. In the context of a Node.js/TypeScript project, the `sanitize-html` library is a popular and robust choice. The fix involves:

- Installing the `sanitize-html` package.
- Importing `sanitizeHtml` from `sanitize-html`.
- Replacing the `removeAllScriptTags` function with a call to `sanitizeHtml`, configured to remove all tags except for a safe subset (or no tags at all, if desired).
- Updating the code to use `sanitizeHtml` for sanitizing `newPassword` and `currentPassword`.

All changes are to be made in `src/app/api/unlock/route.ts`:
- Add the import for `sanitize-html`.
- Remove the `removeAllScriptTags` function.
- Replace its usage with `sanitizeHtml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
