### PR TITLE
Potential fix for code scanning alert no. 339: Bad HTML filtering regexp

### DIFF
--- a/src/app/api/set-password/route.ts
+++ b/src/app/api/set-password/route.ts
@@ -3,7 +3,7 @@ import { hash } from 'bcryptjs';
 import prisma from '@/lib/prisma';
 import { auth } from '@clerk/nextjs/server';
 import { readReplicaDb } from '@/server/read-replica-db';
-
+import sanitizeHtml from 'sanitize-html';
 export async function POST(req: NextRequest) {
   try {
     const { userId } = await auth();
@@ -16,14 +16,7 @@ export async function POST(req: NextRequest) {
     }
     const sanitizedPassword =
       typeof password === 'string'
-        ? (() => {
-            let prev, curr = password;
-            do {
-              prev = curr;
-              curr = curr.replace(/<script.*?>.*?<\/script>/gi, '');
-            } while (curr !== prev);
-            return curr.trim();
-          })()
+        ? sanitizeHtml(password, { allowedTags: [], allowedAttributes: {} }).trim()
         : password;
     if (
       !sanitizedPassword ||


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/339](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/339)

The best way to fix this problem is to avoid using a custom regular expression for HTML sanitization and instead use a well-tested library such as `sanitize-html` or `dompurify`. Since we are only allowed to edit the shown code, we should import a sanitization library and use it to sanitize the password input. This will ensure that all script tags and other potentially dangerous HTML are removed, including malformed or non-standard tags that the regex would miss. The changes should be made in `src/app/api/set-password/route.ts`:

- Add an import for a sanitization library (e.g., `sanitize-html`).
- Replace the custom regex-based sanitization with a call to the library's sanitization function.
- Ensure that the rest of the logic remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
