### PR TITLE
Potential fix for code scanning alert no. 351: Incomplete URL scheme check

### DIFF
--- a/src/components/GlobalAIAssistant.tsx
+++ b/src/components/GlobalAIAssistant.tsx
@@ -134,7 +134,7 @@ const GlobalAIAssistant: React.FC = () => {
     return input
       .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
       .replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, '')
-      .replace(/javascript:/gi, '')
+      .replace(/\b(?:javascript|data|vbscript):/gi, '')
       .replace(/on\w+\s*=/gi, '')
       .trim();
   };


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/351](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/351)

To fix the problem, we need to ensure that the sanitizeInput function removes not only "javascript:" substrings but also "data:" and "vbscript:" (in a case-insensitive manner, and even if there's leading whitespace). This can be achieved in the same `replace()` call, by updating the regular expression to include these other schemes.  

Specifically, in `sanitizeInput`, update the regex on line 137 from `/javascript:/gi` to a pattern that also matches "data:" and "vbscript:" schemes, e.g. `/\b(?:javascript|data|vbscript):/gi`. No functional change to the rest of the sanitization logic is needed.

No new imports or definitions are required since regular expressions and string manipulation are standard features in JavaScript/TypeScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
