### PR TITLE
Potential fix for code scanning alert no. 360: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/ui/SafeImage.tsx
+++ b/src/components/ui/SafeImage.tsx
@@ -2,6 +2,22 @@
 
 import ImageNext from 'next/image';
 
+
+function isValidImageSrc(src: string | null | undefined): boolean {
+  if (!src) return false;
+  try {
+    // Allow http, https, and data:image only
+    if (src.startsWith('data:image/')) {
+      return true;
+    }
+    const url = new URL(src, window.location.origin);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    // If it's a relative path, it will parse as http(s) with window.location.origin
+    return typeof src === 'string' && src.startsWith('/');
+  }
+}
+
 type SafeImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src'> & {
   src: string | null | undefined;
   alt?: string;
@@ -18,7 +34,7 @@ export default function SafeImage({
   className = '',
   ...rest
 }: SafeImageProps) {
-  if (!src) {
+  if (!isValidImageSrc(src)) {
     return <div className={`bg-gray-100 dark:bg-gray-900 ${className}`} aria-hidden />;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/360](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/360)

To securely handle image URLs supplied by users, you should validate the value for the `src` attribute to ensure it is a well-formed URL (absolute or relative, as required) and restrict the allowed URL schemes to safe values (typically `http:`, `https:`, and, if really needed, `data:image/`). Reject or sanitize any URLs with potentially dangerous schemes like `javascript:` or `data:text/html`. The best way to do this is to implement a function like `isValidImageSrc(src)` that performs these checks and only allows safe sources. In the `SafeImage` component (`src/components/ui/SafeImage.tsx`), use this function to validate the value before rendering the `<img>` or `<ImageNext>` element, and render a placeholder if the source is unsafe.

This change should be made inside `src/components/ui/SafeImage.tsx`, before rendering the image. Add an `isValidImageSrc` function in this file, invoke it on `src`, and only render the `<img>` if the value passes validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
