### PR TITLE
Potential fix for code scanning alert no. 360: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/ui/SafeImage.tsx
+++ b/src/components/ui/SafeImage.tsx
@@ -5,16 +5,32 @@ import ImageNext from 'next/image';
 
 function isValidImageSrc(src: string | null | undefined): boolean {
   if (!src) return false;
-  try {
-    // Allow http, https, and data:image only
-    if (src.startsWith('data:image/')) {
-      return true;
+  
+  // Explicitly block potential XSS schemes
+  const forbiddenSchemes = ['javascript:', 'vbscript:', 'file:'];
+  const lowerSrc = src.toLowerCase().trim();
+  for (const scheme of forbiddenSchemes) {
+    if (lowerSrc.startsWith(scheme)) {
+      return false;
     }
+  }
+  
+  // Only allow http, https, or *image* data URIs, and safe relative image paths
+  if (lowerSrc.startsWith('data:image/')) {
+    return true;
+  }
+  // Optionally require relative paths to look like images (ending with common img extensions)
+  const imageExtRegex = /\.(jpg|jpeg|png|gif|webp|svg)$/i;
+  try {
     const url = new URL(src, window.location.origin);
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      // Optionally check pathname for image extension
+      return imageExtRegex.test(url.pathname);
+    }
+    return false;
   } catch {
-    // If it's a relative path, it will parse as http(s) with window.location.origin
-    return typeof src === 'string' && src.startsWith('/');
+    // If it's a relative path (not absolute), check for image extension
+    return typeof src === 'string' && src.startsWith('/') && imageExtRegex.test(src);
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/360](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/360)

To best fix this problem, enhance the `isValidImageSrc` function in `src/components/ui/SafeImage.tsx` to **strictly whitelist only valid image URLs and explicitly block problematic schemes** such as `javascript:`, `data:` (unless it starts with `data:image/`), `vbscript:`, and any unsupported or relative URLs that do not clearly reference an asset. 

- Update `isValidImageSrc` so it **returns `true` ONLY for `http:`, `https:`, and safe `data:image/` URIs** (block all other schemes).
- Explicitly reject any strings starting with `javascript:`, `vbscript:`, `file:`, etc.
- Optionally (recommended) perform a regex match against the URL to ensure it looks like an image resource (ends with `.jpg`, `.jpeg`, `.png`, `.gif`, etc.) or `data:image/...`.
- All edits are confined to `src/components/ui/SafeImage.tsx`, specifically in the `isValidImageSrc` function.
- No extra imports required. Use native JS/TS/React utilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
