### PR TITLE
Potential fix for code scanning alert no. 360: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/ui/SafeImage.tsx
+++ b/src/components/ui/SafeImage.tsx
@@ -17,19 +17,38 @@ function isValidImageSrc(src: string | null | undefined): boolean {
   
   // Only allow http, https, or *image* data URIs, and safe relative image paths
   if (lowerSrc.startsWith('data:image/')) {
-    return true;
+    // Block SVG images in data URIs (XSS vector!)
+    if (/^data:image\/svg\+xml/i.test(lowerSrc)) {
+      return false;
+    }
+    // Only allow known-safe image mimetypes: png, jpeg, gif, webp
+    if (
+      /^data:image\/(png|jpg|jpeg|gif|webp);/i.test(lowerSrc)
+    ) {
+      return true;
+    }
+    // Otherwise disallow
+    return false;
   }
   // Optionally require relative paths to look like images (ending with common img extensions)
-  const imageExtRegex = /\.(jpg|jpeg|png|gif|webp|svg)$/i;
+  const imageExtRegex = /\.(jpg|jpeg|png|gif|webp)$/i; // Do NOT allow svg extension
   try {
     const url = new URL(src, window.location.origin);
     if (url.protocol === 'http:' || url.protocol === 'https:') {
       // Optionally check pathname for image extension
+      // Do NOT allow loading SVGs even with http(s) URLs
+      if (/\.svg$/i.test(url.pathname)) {
+        return false;
+      }
       return imageExtRegex.test(url.pathname);
     }
     return false;
   } catch {
     // If it's a relative path (not absolute), check for image extension
+    // Also disallow SVG in local file paths
+    if (/\.svg$/i.test(src)) {
+      return false;
+    }
     return typeof src === 'string' && src.startsWith('/') && imageExtRegex.test(src);
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/360](https://github.com/Saksham-Goel1107/Dionysus/security/code-scanning/360)

To fix the problem, we need to augment the validation in `isValidImageSrc()` to specifically disallow all SVG image types in data URIs, and optionally even for http(s) image URLs, unless absolutely required and those SVGs are sanitized on the server. This should be done in the SafeImage component, in particular in the `isValidImageSrc` function. We will:

- Disallow SVG images from being included via data URIs: for `data:image/svg+xml` and any other SVG mimetype, return false.
- Optionally, also disallow SVG from http, https, or relative URLs, unless you explicitly trust SVGs hosted on your domain.
- Otherwise, retain the existing image extension checks (jpg, jpeg, png, gif, webp, etc).
- The only affected file is `src/components/ui/SafeImage.tsx`, since this is where the validation logic and the vulnerable sink live.

No additional package is needed; the fix is just to tighten the logic in `isValidImageSrc()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
